### PR TITLE
fix: parse RADOLAN header timestamp as UTC

### DIFF
--- a/R/readHeader.R
+++ b/R/readHeader.R
@@ -21,7 +21,7 @@ out$nchar <- nchar(o) + 1 # +1 for ETX
 
 DDHHMI              <- substr(o,  3,  8)
 MOYY                <- substr(o, 14, 17)
-out$date <- strptime(paste0(DDHHMI,"00-",MOYY), format="%d%H%M%S-%m%y")
+out$date <- strptime(paste0(DDHHMI,"00-",MOYY), format="%d%H%M%S-%m%y", tz="UTC")
 out$product         <- substr(o,  1,  2)
 out$location        <- substr(o,  9, 13) # "10000"
 out$radius_format   <- substr(o, 29, 30) # " 3"


### PR DESCRIPTION
## Summary

`strptime()` in `readHeader` was called without `tz="UTC"`, causing the parsed timestamp to be interpreted in the local system timezone instead of UTC.

RADOLAN header timestamps always encode **UTC times** (confirmed by the DWD Kompositformatbeschreibung and by the Go reference implementation at [`github.com/kellerza/radolan`](https://github.com/kellerza/radolan) which explicitly parses with `time.UTC`). On a `Europe/Berlin` system this produces timestamps that are **3600 s too early** in winter (CET = UTC+1) or **7200 s too early** in summer (CEST = UTC+2).

**Reproduction:** on a Europe/Berlin system, a file with header `RW310850100001217…` (31 Dec 2017, 08:50 UTC) returns epoch `1514710200` instead of the correct `1514703000` — a difference of exactly 3600 s (CET offset).

## Fix

```r
# before
out$date <- strptime(paste0(DDHHMI,"00-",MOYY), format="%d%H%M%S-%m%y")

# after
out$date <- strptime(paste0(DDHHMI,"00-",MOYY), format="%d%H%M%S-%m%y", tz="UTC")
```

## Related

A companion PR against [brry/rdwd](https://github.com/brry/rdwd) fixes the same class of bug in `readDWD.binary` and `readDWD.rklim`, where `as.POSIXct(time)` is called without `tz="UTC"` on the character string produced from this header date.